### PR TITLE
TokenWhitelisted: only apply whitelisting on extention contract

### DIFF
--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -15,11 +15,6 @@ import {IWhitelistV2} from "./interfaces/IWhitelistV2.sol";
 contract Token is ERC20, Ownable, IERC1363 {
     string private _name;
     string private _ticker;
-    IWhitelistV2 public whitelist;
-    bool public whitelistRevoked = false;
-
-    event WhitelistContractUpdated(address indexed whitelist);
-    error WhitelistRevoked();
 
     constructor(string memory name_, string memory ticker_) ERC20(name_, ticker_) Ownable(_msgSender()) {
         _mint(_msgSender(), 100_000_000 * 1e18);
@@ -179,31 +174,5 @@ contract Token is ERC20, Ownable, IERC1363 {
                 }
             }
         }
-    }
-
-    /**
-     * @dev Hook that is called before any transfer of tokens
-     * @param from Address sending tokens
-     * @param to Address receiving tokens
-     * @param amount Amount of tokens being transferred
-     */
-    function _update(address from, address to, uint256 amount) internal virtual override {
-        if (address(whitelist) != address(0)) {
-            require(whitelist.isTransactionAllowed(from, to, amount), "Transaction not allowed by whitelist");
-        }
-        super._update(from, to, amount);
-    }
-
-    function setWhitelist(address _whitelist) external onlyOwner {
-        if (whitelistRevoked) {
-            revert WhitelistRevoked();
-        }
-        whitelist = IWhitelistV2(_whitelist);
-    }
-
-    function disableWhitelist() external onlyOwner {
-        whitelist = IWhitelistV2(address(0));
-        whitelistRevoked = true;
-        emit WhitelistContractUpdated(address(0));
     }
 }

--- a/contracts/extensions/TokenWhitelisted.sol
+++ b/contracts/extensions/TokenWhitelisted.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {Token} from "../Token.sol";
-import {IWhitelist} from "../interfaces/IWhitelist.sol";
+import {IWhitelistV2} from "../interfaces/IWhitelistV2.sol";
 
 /**
  * @title Extended token contract with whitelist contract interactions
@@ -40,7 +40,10 @@ contract TokenWhitelisted is Token {
     function _update(address from, address to, uint256 amount) internal override {
         require(to != address(this), "Cannot transfer to the token contract address");
         if (_whitelistContract != address(0)) {
-            IWhitelist(_whitelistContract).checkWhitelist(from, to, amount);
+            require(
+                IWhitelistV2(_whitelistContract).isTransactionAllowed(from, to, amount),
+                "Transaction not allowed by whitelist"
+            );
         }
         super._update(from, to, amount);
     }

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {Test, console2} from "forge-std/Test.sol";
-import {Token} from "../contracts/Token.sol";
+import {TokenWhitelisted} from "../contracts/extensions/TokenWhitelisted.sol";
 import {WhitelistV2} from "../contracts/WhitelistV2.sol";
 import {IERC1363Receiver} from "../contracts/interfaces/IERC1363Receiver.sol";
 import {IERC1363Spender} from "../contracts/interfaces/IERC1363Spender.sol";
@@ -105,14 +105,14 @@ contract MockERC1363Spender is IERC1363Spender {
     }
 }
 
-contract TokenTest is Test {
+contract TokenWhitelistedTest is Test {
     using SafeERC20 for IERC20;
 
     // The fork
     uint256 mainnetFork;
 
     // Contracts under test
-    Token public tokenA; // Token on chain A
+    TokenWhitelisted public tokenA; // Token on chain A
     WhitelistV2 public whitelist;
 
     // Uniswap contracts
@@ -195,9 +195,9 @@ contract TokenTest is Test {
         whitelist.whitelistPool(address(swapRouter));
 
         // Deploy tokens on both chains with real whitelist
-        tokenA = new Token("Test Token", "TEST");
+        tokenA = new TokenWhitelisted("Test Token", "TEST");
 
-        tokenA.setWhitelist(address(whitelist));
+        tokenA.setWhitelistContract(address(whitelist));
 
         // Deploy mock receiver and spender
         mockReceiver = new MockERC1363Receiver();

--- a/test/WhitelistV2.t.sol
+++ b/test/WhitelistV2.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import "forge-std/Test.sol";
 import "../contracts/WhitelistV2.sol";
-import "../contracts/Token.sol";
+import {TokenWhitelisted} from "../contracts/extensions/TokenWhitelisted.sol";
 import {IUniswapV3Pool} from "../contracts/interfaces/IUniswapV3Pool.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -60,7 +60,7 @@ contract WhitelistV2Test is Test {
 
     // Contracts under test
     WhitelistV2 public whitelist;
-    Token public token;
+    TokenWhitelisted public token;
 
     // Uniswap contracts
     IUniswapV3Factory public uniswapFactory;
@@ -128,9 +128,9 @@ contract WhitelistV2Test is Test {
         whitelist = new WhitelistV2(owner);
 
         // Deploy a test token that uses the whitelist
-        token = new Token("Test Token", "TEST");
+        token = new TokenWhitelisted("Test Token", "TEST");
 
-        token.setWhitelist(address(whitelist));
+        token.setWhitelistContract(address(whitelist));
 
         // Create a new Uniswap pool for our token and WETH
         uint256 tokenAmount = 1000000 * 10 ** 18; // 1M tokens
@@ -617,7 +617,8 @@ contract WhitelistV2Test is Test {
         WhitelistV2 newWhitelist = new WhitelistV2(owner);
 
         // Create token using the new whitelist
-        Token newToken = new Token("New Test Token", "NTEST");
+        TokenWhitelisted newToken = new TokenWhitelisted("New Test Token", "NTEST");
+        newToken.setWhitelistContract(address(newWhitelist));
 
         // Try to check transaction with no oracle set
         newWhitelist.setPhase(WhitelistV2.Phase.LIMITED_POOL_TRADING);


### PR DESCRIPTION
Moves all whitelisting flows to be only applied at the extension contract level, instead of the base token contract