### PR TITLE
stake: remove redundant assignment in migrate

### DIFF
--- a/contracts/Stake.sol
+++ b/contracts/Stake.sol
@@ -366,10 +366,7 @@ contract Stake is IERC1363Spender, ReentrancyGuard, Ownable {
         bool migrationSuccess = false;
         try newStakingContract.depositForUser(userAddress, stakedAmount) {
             migrationSuccess = true;
-        } catch {
-            // If the depositForUser call fails, we need to transfer tokens back to the user
-            migrationSuccess = false;
-        }
+        } catch {}
 
         if (!migrationSuccess) {
             // If migration failed, return tokens to the user's wallet


### PR DESCRIPTION
In the [migrate()](https://github.com/vultisig/vultisig-contract/blob/6c299dd44235505c4081fa6780271cf55f873108/contracts/Stake.sol#L334) function of the Stake contract, there is an unnecessary assignment in the catch block that sets migrationSuccess = false. This is redundant because the variable is already initialised to false before the try-catch block and is only changed to true if the try block succeeds. This issue doesn't affect the contract's functionality but represents inefficient code and a minor gas waste.