### PR TITLE
stake: make onApprovalReceived non-reentrant

### DIFF
--- a/contracts/Stake.sol
+++ b/contracts/Stake.sol
@@ -309,6 +309,7 @@ contract Stake is IERC1363Spender, ReentrancyGuard, Ownable {
     function onApprovalReceived(address owner, uint256 value, bytes calldata /* data */ )
         external
         override
+        nonReentrant
         returns (bytes4)
     {
         require(msg.sender == address(stakingToken), "Stake: caller is not the staking token");


### PR DESCRIPTION
Adds a missing reentrancy guard to Stake.sol