### PR TITLE
stake: fail if reward balance is insufficient for accrued user rewards

### DIFF
--- a/contracts/Stake.sol
+++ b/contracts/Stake.sol
@@ -528,14 +528,14 @@ contract Stake is IERC1363Spender, ReentrancyGuard, Ownable {
 
         // Check if we have enough reward token balance
         uint256 currentRewardBalance = rewardToken.balanceOf(address(this));
-        uint256 rewardAmount = pending > currentRewardBalance ? currentRewardBalance : pending;
+        require(pending <= currentRewardBalance, "Stake: insufficient reward token balance");
 
         // Important: Update lastRewardBalance to track that these tokens are being claimed
-        lastRewardBalance -= rewardAmount;
+        lastRewardBalance -= pending;
 
         // Update reward debt to reflect that rewards have been claimed
         user.rewardDebt = (user.amount * accRewardPerShare) / REWARD_DECAY_FACTOR_SCALING;
 
-        return rewardAmount;
+        return pending;
     }
 }


### PR DESCRIPTION
Under normal circumstances, this check should never be triggered because the contract's accounting of rewards should ensure that the sum of all pending rewards doesn't exceed the contract's balance. If this check does get triggered, it indicates a fundamental accounting error in the contract that should be investigated rather than silently handled.

Recommendations:
Remove the balance check and simply assign the pending amount to the reward amount. If there's truly an issue with insufficient balance, it's better for the transaction to fail transparently so the issue can be identified and addressed.

---

I have elected to add an explicit failure if reward balance is insufficient to meet obligations, rather than implicitly rely on the assumption that the function calling `_claimRewards` will attempt to `safeTransfer` them out and produce a failure.

It is possible that future versions of the Stake contract have internal rebalancing/reinvest flows that simply absorb the reward balance rather than transfer it in some form. Having it as an explicit check reduces the probability of us overlooking this in the future.

Also added a test to ensure this works