### PR TITLE
stake: ensure rewards can only be distributed once per block

### DIFF
--- a/contracts/Stake.sol
+++ b/contracts/Stake.sol
@@ -108,7 +108,7 @@ contract Stake is IERC1363Spender, ReentrancyGuard, Ownable {
         }
 
         uint256 currentRewardBalance = rewardToken.balanceOf(address(this));
-        bool timeDelayMet = (block.timestamp >= lastRewardUpdateTime + minRewardUpdateDelay);
+        bool timeDelayMet = (block.timestamp > lastRewardUpdateTime + minRewardUpdateDelay);
 
         // If there are new rewards and enough time has passed (or delay is set to 0)
         if (currentRewardBalance > lastRewardBalance && timeDelayMet) {
@@ -151,7 +151,7 @@ contract Stake is IERC1363Spender, ReentrancyGuard, Ownable {
             uint256 totalNewRewards = currentRewardBalance - lastRewardBalance;
 
             // Apply decay and time check based on configured parameters
-            if (block.timestamp >= lastRewardUpdateTime + minRewardUpdateDelay) {
+            if (block.timestamp > lastRewardUpdateTime + minRewardUpdateDelay) {
                 // Apply decay - only consider a fraction of the new rewards unless decay factor is 1
                 additionalRewards = totalNewRewards / rewardDecayFactor;
             }

--- a/test/Stake.t.sol
+++ b/test/Stake.t.sol
@@ -196,7 +196,7 @@ contract StakeTest is Test {
         vm.prank(owner);
         rewardToken.transfer(address(stake), 100 ether);
 
-        vm.warp(block.timestamp + 1 days);
+        vm.warp(block.timestamp + 1 days + 1);
 
         // Update rewards
         stake.updateRewards();
@@ -219,7 +219,7 @@ contract StakeTest is Test {
         vm.prank(owner);
         rewardToken.transfer(address(stake), 100 ether);
 
-        vm.warp(block.timestamp + 1 days);
+        vm.warp(block.timestamp + 1 days + 1);
 
         // Update rewards and claim
         vm.startPrank(user);
@@ -544,7 +544,7 @@ contract StakeTest is Test {
         rewardToken.transfer(address(stake), initialRewards);
 
         // Advance time and update rewards
-        vm.warp(block.timestamp + 1 days);
+        vm.warp(block.timestamp + 1 days + 1);
         stake.updateRewards();
 
         // Maliciously transfer out most of the reward tokens to simulate a balance shortage

--- a/test/StakeMigration.t.sol
+++ b/test/StakeMigration.t.sol
@@ -102,6 +102,7 @@ contract StakeMigrationTest is Test {
         oldStake.setRewardDecayFactor(1); // No decay (release all rewards)
         vm.stopPrank();
 
+        vm.warp(block.timestamp + 1);
         // Update rewards - with the parameters set above, all rewards will be processed
         oldStake.updateRewards();
 
@@ -208,6 +209,7 @@ contract StakeMigrationTest is Test {
         oldStake.setRewardDecayFactor(1);
         vm.stopPrank();
 
+        vm.warp(block.timestamp + 1);
         // Update rewards to distribute them
         oldStake.updateRewards();
 

--- a/test/StakeReinvest.t.sol
+++ b/test/StakeReinvest.t.sol
@@ -77,6 +77,7 @@ contract StakeReinvestTest is Test {
         vm.prank(owner);
         rewardToken.transfer(address(stake), REWARD_AMOUNT);
 
+        vm.warp(block.timestamp + 1);
         // Update rewards to calculate distribution
         stake.updateRewards();
 
@@ -194,6 +195,7 @@ contract StakeReinvestTest is Test {
         stake.setMinRewardUpdateDelay(0); // No delay
         vm.stopPrank();
 
+        vm.warp(vm.getBlockTimestamp() + 1);
         stake.updateRewards();
 
         // User claims half the rewards
@@ -204,6 +206,7 @@ contract StakeReinvestTest is Test {
         vm.prank(owner);
         rewardToken.transfer(address(stake), REWARD_AMOUNT);
 
+        vm.warp(vm.getBlockTimestamp() + 1);
         // Update rewards again to make new rewards available
         stake.updateRewards();
 
@@ -239,6 +242,7 @@ contract StakeReinvestTest is Test {
         vm.prank(owner);
         rewardToken.transfer(address(stake), REWARD_AMOUNT);
 
+        vm.warp(block.timestamp + 1);
         // Update rewards to calculate distribution
         stake.updateRewards();
 


### PR DESCRIPTION
Previously, rewards could vest more than once per block - this enabled flash loan attacks, allowing attackers to drain rewards.

With this update, rewards can only update once per block, making same-block flashloan attack infeasible.